### PR TITLE
fix: Add correct Khan Academy link

### DIFF
--- a/data/companies.yaml
+++ b/data/companies.yaml
@@ -53,7 +53,7 @@
 - name: Huawei
   url: http://www1.huawei.com/en/about-huawei/Partner/openathuawei/index.htm
 - name: Khan Academy
-  url: IBM
+  url: https://www.khanacademy.org/
 - name: IBM
   url: http://ibm.github.io/
 - name: Indeed


### PR DESCRIPTION
The Khan Academy link is not IBM.