### PR TITLE
Create todo-contribution-guidelines.md

### DIFF
--- a/content/en/guides/casestudies/todo-contribution-guidelines.md
+++ b/content/en/guides/casestudies/todo-contribution-guidelines.md
@@ -1,5 +1,6 @@
-
-# Open Source Program Office Case Study Guidelines
+---
+title: Open Source Program Office Case Study Guidelines
+---
 
 The TODO OSPO Case Study initiative features real-world use cases and the impact OSPO Programs and open source are having on an organization.
 OSPO Use Cases build narratives around open source organization’s journey that includes Open Source Program Office highlighted activities, organizational structure,

--- a/content/en/guides/casestudies/todo-contribution-guidelines.md
+++ b/content/en/guides/casestudies/todo-contribution-guidelines.md
@@ -1,0 +1,65 @@
+
+# Open Source Program Office Case Study Guidelines
+
+The TODO OSPO Case Study initiative features real-world use cases and the impact OSPO Programs and open source are having on an organization.
+OSPO Use Cases build narratives around open source organization’s journey that includes Open Source Program Office highlighted activities, organizational structure,
+best practices, goals, and success stories, showcasing participating organizations as leaders in the OSPO field.
+
+## Requirements
+
+**Who can be featured in an OSPO Case Study?**
+
+As a rule, OSPO case studies feature:
+
+* Private and public organizations running an OSPO or an open source initiative
+* TODO members
+
+All case studies must demonstrate at least one tangible business impact of OSPOs within the
+organization and/or open source ecosystem. Examples from published case studies include the
+work done at OSPOs in terms of:
+
+* Compliance, legal, and developer education
+* Evangelizing Open Source Culture and Usage
+* Hosting Open Source Projects
+* Growing Open Source Communities
+* Improving leadership and becoming a decision-making partner
+* OSPO Best practices (e.g tooling, documentation, etc)
+
+## OSPO Case Study Process
+OSPO case studies follow a self-service model with editorial support and guidance provided by TODO Group and LF.
+
+The self-service follows a five-step process:
+
+**1. Proposal**
+
+Organizations submit a case study proposal
+
+**2. Review**
+* TODO steering committee team reviews proposal within 30 working days
+* If the proposal meets the criteria, the TODO PM sends a case study pack to the contact info provided
+* If the proposal doesn’t meet the criteria, TODO Program Manager will provide feedback and the organization is invited to resubmit.
+
+**3. Creation**
+
+Primary contact writes a case study following the required style documented in the case study pack
+
+**4. Editing**
+* TODO Group reviews the case study and makes any necessary edits as suggestions
+* Edits are based on the style guide.
+* Primary contact is welcome to make further edits or additions to the case study
+* Primary contact confirms when the draft is final and manages any approval processes
+
+**5. Publishing**
+* TODO and LF prepare the case study for publication
+* Primary Contact will receive a preview link, to view the case study before it goes live.
+* Case Study is published to todogroup.org and OSPO guide
+* Promotion cycle begins
+
+**6. Promotion**
+* Case studies are published on todogorup.org. TODO Group and LF market the case studies online, through social media, blog promotion, and the TODO OSPO newsletter.
+
+## To get started
+
+Propose a case study and send it to the team directly uby filling out this GitHub form
+
+> If you have any questions or feedback about the OSPO Case Study initiative, please send an email to info@todogroup.io.

--- a/content/en/guides/todo-guides-contribution-guidelines.md
+++ b/content/en/guides/todo-guides-contribution-guidelines.md
@@ -1,0 +1,50 @@
+---
+title: TODO Guides Contributing Guidelines
+---
+
+These Open Source Guides are developed by the TODO Group in collaboration with The Linux Foundation and the larger open source community. 
+They collect best practices from the leading organizations engaged in open source development and aim to help your organization successfully 
+implement and run an open- source program office. We expect these guides to be living documents that evolve via community contributions.
+
+## Requirements
+
+**Who can be featured in a TODO Guide?**
+
+TODO GH Repo is an Open Source project under CC-BY 4.0 Licence, which means everyone can contribute and be acknowledged as an individual 
+contributor to any of the existing TODO repositories. Types of contributions we're looking for
+
+There are many ways you can directly contribute to the guides:
+
+* Feature a new TODO Guide
+* Update existing TODO Guides to fit current OSPO needs
+* Fix editorial inconsistencies or inaccuracies from existing guides
+* Translate guides into other languages
+
+## Feature a new guide
+
+If you'd like to contribute by adding a new guide, start by searching through the issues and pull requests to see whether 
+someone else has raised a similar idea or question.If you don't see your idea listed, and you think it fits into the goals 
+of this guide- Please follow the following steps:
+
+**Step One: Creation Process**
+
+* Open an issue using the `guide` tag: Please tell us about how this guide will benefit the OSPO Ecosystem and interested participants. 
+Also, we will ask about adding an initial draft of the proposed guide (this can be changed later). This issue is raised to the TODO 
+Community reaching for feedback and new contributors.
+
+* Open a PR that links to the issue: Such PR should make editions to todogroup.org guides folder by adding a new.md file. 
+For instance, if your proposed todo guide is “how to set up an OSPO” the md file should be stated ad “how-to-set-up-an-ospo.md”
+
+**Step 2: Review Process**
+TODO PM, SC members, and the broader TODO Community can provide feedback and review the PR.
+
+**Step 3: Guide Publication**
+Once the guide is finished and ready to go. The PR is merged and the guide will appear at todogroup.org
+
+**Step 4: Outreach**
+The new guide will be promoted on TODO SM channels, OSPONews and OSPOlogy upcoming sessions. 
+Moreover, the contributors participating in this guide can request to have this guide added as an LF blog post by contacting info@todogroup.org
+
+
+
+

--- a/content/en/guides/whitepaper-guidelines.md
+++ b/content/en/guides/whitepaper-guidelines.md
@@ -1,0 +1,59 @@
+---
+title: TODO Whitepaper Guidelines
+---
+
+The TODO Whitepapers inform about specific open source topics demanded by the OSPO community, in order to help the community 
+to understand an issue, provide more documentation, or solve a problem.
+
+# How to contirbute
+
+There are many ways you can directly contribute to a TODO whitepapaer:
+
+* 1. Feature a new TODO Whitepapaer
+* 2. Contirbute to a WIP TODO Whitepaper
+* 3. Fix editorial inconsistencies or inaccuracies from existing Whitepapaers
+* 4. Translate Whitepapaers into other languages
+
+## 1. Feature a new TODO Whitepapaer
+
+**Idea submission:** 
+
+A request is submitted by opening an issue at TODO governance repo using the tag `whitepapaer`
+
+**Steering Committee Review:** 
+
+The TODO Steering Committee reviews the proposal
+
+**Community feedback:** 
+
+The issue is shared to the TODO Community asking for feedback and interested contributors.
+
+**Creation proces:**
+
+TODO PM creates a new repo that gather the whitepapaer content. Bi-weekly sync meetigns can be requested to review whitepapaer's evolution.
+
+**Publication process:**
+
+Once the final version for the whitepaper content is approved, TODO PM sends this to LF team to work on design and starts publication and promotion 
+process through the main TODO and LF communication channels.
+
+## 2. Contirbute to a WIP TODO Whitepaper
+
+Bellow is a list of current WIP Whitepapaers and their dedicated repos. Please check the `CONTRIBUTING.md` file on each repo to learn more.
+
+* [Outbound OSS Whitepaper](https://github.com/todogroup/outbound-oss)
+
+# Examples
+
+Bellow is a list of published and WIP TODO Whitepapers:
+
+**Why Open Source Matters to your Enterprise**
+
+[This paper](https://www.linuxfoundation.org/tools/todo-group-why-open-source-matters-to-your-enterprise/), published by the European Chapter of the TODO Group, aims to provide a balanced and quick overview of the 
+business pros and cons of using open source software.
+
+**Outbound OSS**
+
+A WIP Whitepaper maintain by the TODO European Chapter which content is being managed in a dedicated TODO Org repo. [Such repo](https://github.com/todogroup/outbound-oss) contains documentation and guidance for 
+handling outbound OSS in organzations.
+


### PR DESCRIPTION
This commit creates adds contribution guidelines in the todo website that documents the process and requirements when creating and proposing:

* OSPO Use Cases
* TODO Guides
* TODO Whitepapers