### PR TITLE
update content from resources, community and improve navbar view

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,19 +32,19 @@ languages:
     footer:
     - title: Home
       link: /
-    - title: Blog
-      link: /blog
-    - title: Guides
-      link: /guides
     - title: About
       link: /about
-    - title: Community
+    - title: 📚 Guides & Resources
+      link: /guides
+    - title: 🙋 Community & Network
       link: /community
-    - title: Members
+    - title: 📝 Blog
+      link: /blog
+    - title: 💚 Members
       link: /members
-    - title: Join
+    - title: 👋 Join
       link: /join
-    - title: Q&A
+    - title: 💬 Q&A
       link: /faq
   ja:
     languageName: 日本語

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -20,14 +20,40 @@ Are you new to our community? We invite you to join us on the different communic
 * Europe Chapter: TODO Group Slack #chapter-europe
 * APAC Chapter: TBD
 
-# 🙋 Meetings and calls
+# 🙋 Meetings and Conferences
 
-## Community:
+## Conferences
 
-* [OSPOlogy](https://github.com/todogroup/ospology/tree/main/meetings#ospology-monthly-meetings)
-* [Europe Sync meetings](https://github.com/todogroup/ospology#todo-eu-chapter-sync-meetings-monthly)
-* [APAC Sync meetings](https://github.com/todogroup/ospology/discussions/67)
-* [Work Day Activities](https://github.com/todogroup/work-day-activities)
+The global in-person & virtual conferences where those working in open source program offices (or [similar initiatives](https://github.com/todogroup/ospology/discussions/16)) in organizations that rely on open source technologies come together to learn and share best practices, experiences and tooling to overcome challenges they face. 
+OSPOCon is presented by the TODO Group and The Linux Foundation and as part of OSSummit event series.
+
+**Upcomming Conferences**
+
+* `🌎 OSPOCon North America 2022:` [June 21-24](https://events.linuxfoundation.org/open-source-summit-north-america/about/ospocon/) • Austin, Texas 🇺🇸 & Virtual
+* `🌍 OSPOCon Europe 2022:` [September 13-16](https://events.linuxfoundation.org/open-source-summit-europe/about/ospocon/) • Dublin, Ireland 🇮🇪 & Virtual
+* `🌏 OSPOCon Japan 2022:` [December 5-6](https://events.linuxfoundation.org/open-source-summit-japan/about/ospocon/) • Yokohama, Japan 🇯🇵 & Virtual
+
+**Past Conferences**
+
+* OSPOCon North America 2021
+* OSPOCon Europe 2021
+
+## Meetings & Calls
+
+### Community
+
+* Network & Learning Space
+
+    * **OSPOlogy:** [Global Community Meetings](https://github.com/todogroup/ospology/tree/main/meetings#ospology-monthly-meetings)
+        * Submitt a [CFP](https://github.com/todogroup/ospology/issues/new/choose)
+    * **Europe Sync:** [Regional Calls](https://github.com/todogroup/ospology#todo-eu-chapter-sync-meetings-monthly) part of TODO Europe Chapter
+    * **APAC Sync:** [Regional Calls](https://github.com/todogroup/ospology/discussions/67) part of TODO APAC Chapter
+
+* Contributor Space
+
+    * [Work Day Activities](https://github.com/todogroup/work-day-activities)
+        * EMEA & APAC
+        * AMER
 
 {{< calendar >}}
 
@@ -41,11 +67,12 @@ Are you new to our community? We invite you to join us on the different communic
 🕐 Need help with timezone conversions? Check out [worldtimebuddy.com](worldtimebuddy.com).
 
 
-## General Members Sync:
+### General Members Sync:
 
 Sometimes, there are community participants with an established OSPO or open source initiative who wish to become General Members. Touchpoint calls are the General Member Sync meetings.
 
 * Touchpoints
+
 
 # 📝 Contribution Guidelines
 
@@ -87,7 +114,7 @@ Please take a look at TODO General Member [Onboarding checklist](https://github.
 We welcome you [to join TODO as General Members](/join).
 
 
-# TODO Steering Committee
+# 🧩 TODO Steering Committee
 
 We elect members to the TODO Group Steering Committee every year. These members are charged with coordinating with the group’s Program Manager to manage day-to-day operations of the group, overseeing all business and marketing matters, helping to create working groups and helping to define the TODO Group community’s strategic goals. [Learn more.](https://github.com/todogroup/governance/blob/master/CHARTER.adoc)
 

--- a/content/en/guides/_index.md
+++ b/content/en/guides/_index.md
@@ -1,17 +1,22 @@
 ---
-title: Guides and additional resources
+title: Guides and Resources
 ---
-The TODO Group offers a set of **OSPO Guides**, **OSPO Personas**, and **Case Studies**, as well as a **Maturity Model**, **Annual Surveys**, and **OSPO 101 Course**, to help organizations advance in their OSPO journey. These OSPO resources are developed by the TODO Group in collaboration with The Linux Foundation and the larger open source community. We expect these resources to be living documents that evolve via community contributions.
+The TODO Group offers a **Maturity Model**, a set of **Guides**, a **Mind Map**, a **101 Course**, **Annual Surveys**, as well as **Case Studies**, to help organizations advance in their OSPO journey. These OSPO resources are developed by the TODO Group in collaboration with The Linux Foundation and the larger open source community. We expect these resources to be living documents that evolve via community contributions.
 
-* [The Evolution of the OSPO study](https://linuxfoundation.org/tools/the-evolution-of-the-open-source-program-office-ospo/): Includes an OSPO maturity model, practical implementation from noted OSPO programs across regions and sectors, and a set of OSPO personas. People can download the [PDF Version here](https://linuxfoundation.org/wp-content/uploads/LFResearch_OSPO_Report.pdf)
+* 🚀 [The Evolution of the OSPO study](https://linuxfoundation.org/tools/the-evolution-of-the-open-source-program-office-ospo/): Includes an OSPO maturity model, practical implementation from noted OSPO programs across regions and sectors, and a set of OSPO personas. People can download the PDF version in multiple languages:
+    * [English](https://linuxfoundation.org/wp-content/uploads/LFResearch_OSPO_Report.pdf)
+    * [日本語](https://www.linuxfoundation.jp/wp-content/uploads//2022/05/LFResearch_OSPO_Report-jp.pdf)
+> *Translations are done via community contributions. Please send an email to info@todogroup.org to contribute to other translations*
 
-* **TODO OSPO Guides:** Collect best practices from the leading companies engaged in open source development and aim to help your organization successfully implement and run an open source program office. For guides tailored to individual contributors, we recommend GitHub’s [community guides](https://github.com/github/opensource.guide).
+* 📝 [TODO OSPO Guides](#ospo-guides): Collect best practices from the leading companies engaged in open source development and aim to help your organization successfully implement and run an open source program office. For guides tailored to individual contributors, we recommend GitHub’s [community guides](https://github.com/github/opensource.guide).
 
-* [OSPO 101 Course](https://github.com/todogroup/ospo101): Covers everything you need to know about Open Source Program Offices. The course materials are modular, available on GitHub, and licensed under a Creative Commons license, allowing them to be remixed and reused as needed.
+* 🧭 [OSPO Mind Map](https://ospomindmap.todogroup.org/): An interactive Mind Map that schemes the main Open Source program Office's responsibilities, roles, behavior and team size within the Ecosystem. Project can be found as part of [OSPOlogy repo](https://github.com/todogroup/ospology/tree/main/ospo-mindmap).
 
-* [OSPO Annual Surveys](https://github.com/todogroup/osposurvey): The TODO Group is committed to running this survey on an annual basis moving forward and sharing the results with the wider community. Learn more here.
+* 📚 [OSPO 101 Course](https://github.com/todogroup/ospo101): Covers everything you need to know about Open Source Program Offices. The course materials are modular, available on GitHub, and licensed under a Creative Commons license, allowing them to be remixed and reused as needed.
 
-* **Case Studies:** Practical Case Studies to learn from OSPOs or similar open source initiatives within organizations.
+* 📈 [OSPO Annual Surveys](https://github.com/todogroup/osposurvey): The TODO Group is committed to running this survey on an annual basis moving forward and sharing the results with the wider community. Learn more here.
+
+* 🔎 [Case Studies](#ospo-case-studies): Practical Case Studies to learn from OSPOs or similar open source initiatives within organizations.
 
 ## OSPO Guides
 
@@ -47,7 +52,7 @@ For open source program management best practices:
 
 It is intended to be a modularized so the content is reusable in a piecemeal fashion.
 
-## Open Source Program Case Studies
+## OSPO Case Studies
 
 * [Autodesk](casestudies/autodesk)
 * [Capital One](casestudies/capitalone)


### PR DESCRIPTION
This commit:

* Adds the new resources that have been recently published at TODO, including:
    * OSPO mind map
    * Evolution of the OSPO Japanese translation
* Adds OSPOCon conference series info and more details from the TODO networking spaces
* Improve navbar view