### PR TITLE
clarify community structure

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -113,7 +113,7 @@ We welcome you [to join TODO as General Members](/join).
 
 ***
 
-| 💚 Brand | 🙋‍♀️ Audience | 🎯 Purpose | 🔍 Definition | 📚Docs |
+| Brand | Audience | Purpose | Definition | Docs |
 | --- | --- | --- | --- |  --- |
 | **OSPOlogy**| Community | Adoption, Contribution and Network | Hosts the OSPO resources, regional chapters, contribution spaces and open community communication to discuss open source program offices| <li>[OSPOlogy Repo](https://github.com/todogroup/ospology)</li><li>#General slack</li><li>Community Mailing List</li> | 
 | **OSPOCon** | Community | Adoption and Network | here those working in open source program offices in organizations that rely on open source technologies come together to learn and share best practices, experiences and tooling to overcome challenges they face | [Linux Foundation Events](https://events.linuxfoundation.org/) | 

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -2,57 +2,52 @@
 title: "Community & Network"
 permalink: /community/
 ---
-If you are new to TODO Group Community, [this guide](https://github.com/todogroup/governance/blob/main/onboarding/community.md#todo-community-onboarding) should provide helpful onboarding resources.
 
 [Edit this page on GitHub](https://github.com/todogroup/todogroup.org)
+
+* If you are new in the OSPOlogy Community, [this guide](https://github.com/todogroup/governance/blob/main/onboarding/community.md#todo-community-onboarding) should provide helpful onboarding resources.
+
+* If you are a new TODO General Member, [this guide](https://github.com/todogroup/governance/blob/main/onboarding/general-member.md) should provide helpful onboarding resources.
+
 
 # 💬 Communication channels
 
 Are you new to our community? We invite you to join us on the different communication Channels:
 
+* [Slack](https://join.slack.com/t/thetodogroup/shared_invite/zt-169ok18cz-Pi6tpVHTeW9254d1FpkLew): Includes OSPOlogy and TODO Member communication channels
+* [OSPOlogy Community Mailing List](https://docs.google.com/forms/d/e/1FAIpQLSeU0YGM_IJ6gY8E5IIiwXKD_FZi3kAVc4E9_-3dtTDyKMSjdA/viewform)
+* [OSPOlogy Forum (GH Discussions)](https://github.com/todogroup/ospology/discussions)
 
-* [TODO Group Slack](https://join.slack.com/t/thetodogroup/shared_invite/zt-169ok18cz-Pi6tpVHTeW9254d1FpkLew)
-* [TODO Community Mailing List](https://docs.google.com/forms/d/e/1FAIpQLSeU0YGM_IJ6gY8E5IIiwXKD_FZi3kAVc4E9_-3dtTDyKMSjdA/viewform)
-* [OSPO Forum (GH Discussions)](https://github.com/todogroup/ospology/discussions)
+**OSPOlogy Regional Communication Channels**
 
-**TODO Chapters Communication Channels**
+* Europe Chapter: Slack channel #chapter-europe
+* APAC Chapter: Slack channel #chapter-apac
 
-* Europe Chapter: TODO Group Slack #chapter-europe
-* APAC Chapter: TBD
+# ⭐️ Structure
+
+| Brand | Audience | Purpose | Definition | Docs |
+| --- | --- | --- | --- |  --- |
+| OSPOlogy| Community | Adoption, Contribution and Network | Hosts the OSPO resources, regional chapters, contribution spaces and open community communication to discuss open source program offices| <li>[OSPOlogy Repo](https://github.com/todogroup/ospology)</li><li>#General slack</li><li>Community Mailing List</li> | 
+| OSPOCon | Community | Adoption and Network | here those working in open source program offices in organizations that rely on open source technologies come together to learn and share best practices, experiences and tooling to overcome challenges they face | [Linux Foundation Events](https://events.linuxfoundation.org/) | 
+| TODO GH Project | Community | Adoption, Contribution and Network | All TODO resources and tools are open and free to use and contribute. Source code and content are hosted at TODO Group's GitHub Organization under CC-BY 4.0 Licence | [TODO GH Organization](https://github.com/todogroup) |
+| Touchpoint | General Members | Network | Private space for TODO Members to share sensitive information about their organizations. Information is later anonymized and shared with the wider OSPO community via [OSPOlogy Discussions](https://github.com/todogroup/ospology/discussions)| <li>Touchpoint calls</li><li>#private-generalmembers slack</li><li>General Member Mailing List</li> | 
 
 # 🙋 Meetings and Conferences
 
-## Conferences
-
-The global in-person & virtual conferences where those working in open source program offices (or [similar initiatives](https://github.com/todogroup/ospology/discussions/16)) in organizations that rely on open source technologies come together to learn and share best practices, experiences and tooling to overcome challenges they face. 
-OSPOCon is presented by the TODO Group and The Linux Foundation and as part of OSSummit event series.
-
-**Upcoming Conferences**
-
-* `🌎 OSPOCon North America 2022:` [June 21-24](https://events.linuxfoundation.org/open-source-summit-north-america/about/ospocon/) • Austin, Texas 🇺🇸 & Virtual
-* `🌍 OSPOCon Europe 2022:` [September 13-16](https://events.linuxfoundation.org/open-source-summit-europe/about/ospocon/) • Dublin, Ireland 🇮🇪 & Virtual
-* `🌏 OSPOCon Japan 2022:` [December 5-6](https://events.linuxfoundation.org/open-source-summit-japan/about/ospocon/) • Yokohama, Japan 🇯🇵 & Virtual
-
-**Past Conferences**
-
-* OSPOCon North America 2021
-* OSPOCon Europe 2021
-    * [🍿 Recording sessions](https://www.youtube.com/watch?v=5ML8EaXV3Vk&list=PLbzoR-pLrL6q-dYnjrPbF5in7VR4-8-ZU&ab_channel=TheLinuxFoundation)
-
 ## Meetings & Calls
 
-### Community
+### OSPOlogy: Community
 
 * Network & Learning Space
 
-    * **OSPOlogy:** [Global Community Meetings](https://github.com/todogroup/ospology/tree/main/meetings#ospology-monthly-meetings)
+    * **OSPOlogy Webinars:** [Global Community Meetings](https://github.com/todogroup/ospology/tree/main/meetings#ospology-monthly-meetings)
         * Submit a [CFP](https://github.com/todogroup/ospology/issues/new/choose)
-    * **Europe Sync:** [Regional Calls](https://github.com/todogroup/ospology#todo-eu-chapter-sync-meetings-monthly) part of TODO Europe Chapter
-    * **APAC Sync:** [Regional Calls](https://github.com/todogroup/ospology/discussions/67) part of TODO APAC Chapter
+    * **OSPOlogy Europe Sync:** [Regional Calls](https://github.com/todogroup/ospology#todo-eu-chapter-sync-meetings-monthly) part of TODO Europe Chapter
+    * **OSPology APAC Sync:** [Regional Calls](https://github.com/todogroup/ospology/discussions/67) part of TODO APAC Chapter
 
 * Contributor Space
 
-    * [Work Day Activities](https://github.com/todogroup/work-day-activities)
+    * [Working Hours](https://github.com/todogroup/work-day-activities)
         * EMEA & APAC
         * AMER
 
@@ -68,45 +63,54 @@ OSPOCon is presented by the TODO Group and The Linux Foundation and as part of O
 🕐 Need help with timezone conversions? Check out [worldtimebuddy.com](worldtimebuddy.com).
 
 
-### General Members Sync:
+### General Members: Touchpoints
 
 Sometimes, there are community participants with an established OSPO or open source initiative who wish to become General Members. Touchpoint calls are the General Member Sync meetings.
 
 * Touchpoints
 
+Information is later anonymized and shared with the wider OSPO community via [OSPOlogy Discussions](https://github.com/todogroup/ospology/discussions).
 
-# 📝 Contribution Guidelines
+## Conferences
 
-* [OSPO Case Study Submission Guidelines](https://todogroup.org/guides/casestudies/todo-contribution-guidelines/)
-* [TODO Guides Contributing Guidelines](https://todogroup.org/guides/todo-guides-contribution-guidelines/)
-* [TODO Whitepaper Guidelines](https://todogroup.org/guides/whitepaper-guidelines/)
+The global in-person & virtual conferences where those working in open source program offices (or [similar initiatives](https://github.com/todogroup/ospology/discussions/16)) in organizations that rely on open source technologies come together to learn and share best practices, experiences and tooling to overcome challenges they face. 
+OSPOCon is presented by the TODO Group and The Linux Foundation and as part of OSSummit event series.
+
+**Upcoming Conferences**
+
+* `🌏 OSPOCon Japan 2022:` [December 5-6](https://events.linuxfoundation.org/open-source-summit-japan/about/ospocon/) • Yokohama, Japan 🇯🇵 & Virtual
+
+**Past Conferences**
+
+* OSPOCon North America 2022
+* OSPOCon Europe 2022
+* OSPOCon North America 2021
+* OSPOCon Europe 2021
+    * [🍿 Recording sessions](https://www.youtube.com/watch?v=5ML8EaXV3Vk&list=PLbzoR-pLrL6q-dYnjrPbF5in7VR4-8-ZU&ab_channel=TheLinuxFoundation)
 
 ## OSPOlogy CFP
 
 If you have a story to share, please add your topic to the following [CFP form](https://github.com/todogroup/ospology/issues/new/choose)
 
-# 📚 TODO Community Resources
+# 📚 OSPO Resources
 
-TODO resources are open to everyone and available at TODO Group GitHub repo under CC-BY 4.0 Licence. You can see all the TODO Community resources in the [TODO GH README ORG](https://github.com/todogroup#-discover-the-todo-resources-and-initiatives)
+OSPO resources by TODO are open to everyone and available at TODO Group GitHub repo under CC-BY 4.0 Licence. You can see all the resources in the [TODO GH README ORG](https://github.com/todogroup#-discover-the-todo-resources-and-initiatives). Remember to check out our [OSPO guides](https://todogroup.org/guides/) for more help getting your OSPO started or implementing best practices. If you have ideas for how we can better support you, [open a discussion](https://github.com/todogroup/ospology/discussions). We look forward to hearing from you! 
 
 ## OSPOlogy
 
-If you’re new to TODO Group, or to OSPOs, we encourage you to join one of our upcoming OSPOlogy sessions. 
+[OSPOlogy](https://github.com/todogroup/ospology) hosts the study and open community communication to discuss the status of open source program offices across regions. In this repo the community will find further information about:
 
-These virtual, monthly calls focus on open source program best practices, and allow community members to learn from each other. Joining a call is a great way to meet other community members, or learn about initiatives you may want to participate in. You can join an [upcoming session](https://community.linuxfoundation.org/todo-group/) to ask the experts questions, or even sign up to teach one!
-
-We also have regular [OSPOlogy discussions](https://github.com/todogroup/ospology/discussions). Browse the current topics, or open a new one. Make sure to join us on Slack so that you can get the most out of it. 
-
-Remember to check out our [OSPO guides](https://todogroup.org/guides/) for more help getting your OSPO started or implementing best practices. If you have ideas for how we can better support you, [open a discussion](https://github.com/todogroup/ospology/discussions). We look forward to hearing from you! 
-
-## TODO Discussions
-
-To discuss issues with the TODO Group you're welcome to open a new discussion at [OSPOlogy discussions](https://github.com/todogroup/ospology/discussions).
-
-You can also reach out to [info@todogroup.org](mailto:info@todogroup.org) with any questions.
+* OSPOlogy Webinars
+* OSPOlogy Sync Calls
+        Europe
+        APAC
+* OSPOlogy Working Hours
+* OSPOlogy Discussions (Forum)
+* OSPOlogy Live Europe
+* OSPO Local Communities & Meetups
 
 
-## TODO General Member Resources
+## TODO General Members
 
 The [members of this group](/members) of this group at times share sensitive information and use a private mailing list for that type of discussion. Information shared in this channel is later anonymized and shared with the wider OSPO community via [OSPO Discussions](https://github.com/todogroup/ospology/discussions).
 

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -23,15 +23,6 @@ Are you new to our community? We invite you to join us on the different communic
 * Europe Chapter: Slack channel #chapter-europe
 * APAC Chapter: Slack channel #chapter-apac
 
-# ⭐️ Structure
-
-| Brand | Audience | Purpose | Definition | Docs |
-| --- | --- | --- | --- |  --- |
-| OSPOlogy| Community | Adoption, Contribution and Network | Hosts the OSPO resources, regional chapters, contribution spaces and open community communication to discuss open source program offices| <li>[OSPOlogy Repo](https://github.com/todogroup/ospology)</li><li>#General slack</li><li>Community Mailing List</li> | 
-| OSPOCon | Community | Adoption and Network | here those working in open source program offices in organizations that rely on open source technologies come together to learn and share best practices, experiences and tooling to overcome challenges they face | [Linux Foundation Events](https://events.linuxfoundation.org/) | 
-| TODO GH Project | Community | Adoption, Contribution and Network | All TODO resources and tools are open and free to use and contribute. Source code and content are hosted at TODO Group's GitHub Organization under CC-BY 4.0 Licence | [TODO GH Organization](https://github.com/todogroup) |
-| Touchpoint | General Members | Network | Private space for TODO Members to share sensitive information about their organizations. Information is later anonymized and shared with the wider OSPO community via [OSPOlogy Discussions](https://github.com/todogroup/ospology/discussions)| <li>Touchpoint calls</li><li>#private-generalmembers slack</li><li>General Member Mailing List</li> | 
-
 # 🙋 Meetings and Conferences
 
 ## Meetings & Calls
@@ -118,6 +109,17 @@ Please take a look at TODO General Member [Onboarding checklist](https://github.
 
 We welcome you [to join TODO as General Members](/join).
 
+# ⭐️ Structure
+
+***
+
+| 💚 Brand | 🙋‍♀️ Audience | 🎯 Purpose | 🔍 Definition | 📚Docs |
+| --- | --- | --- | --- |  --- |
+| **OSPOlogy**| Community | Adoption, Contribution and Network | Hosts the OSPO resources, regional chapters, contribution spaces and open community communication to discuss open source program offices| <li>[OSPOlogy Repo](https://github.com/todogroup/ospology)</li><li>#General slack</li><li>Community Mailing List</li> | 
+| **OSPOCon** | Community | Adoption and Network | here those working in open source program offices in organizations that rely on open source technologies come together to learn and share best practices, experiences and tooling to overcome challenges they face | [Linux Foundation Events](https://events.linuxfoundation.org/) | 
+| **TODO GH Project** | Community | Adoption, Contribution and Network | All TODO resources and tools are open and free to use and contribute. Source code and content are hosted at TODO Group's GitHub Organization under CC-BY 4.0 Licence | [TODO GH Organization](https://github.com/todogroup) |
+| **Touchpoint** | General Members | Network | Private space for TODO Members to share sensitive information about their organizations. Information is later anonymized and shared with the wider OSPO community via [OSPOlogy Discussions](https://github.com/todogroup/ospology/discussions)| <li>Touchpoint calls</li><li>#private-generalmembers slack</li><li>General Member Mailing List</li> | 
+
 
 # 🧩 TODO Steering Committee
 
@@ -133,15 +135,6 @@ We elect members to the TODO Group Steering Committee every year. These members 
 - [Thomas Steenbergen](https://github.com/tsteenbe), EPAM
 - [VM (Vicky) Brasseur](https://github.com/vmbrasseur), Wipro
 
-
-
-# 🌏 TODO Chapters
-
-**TODO EU Chapter**
-
-The TODO EU chapter was formed by TODO Members based in Europe. This chapter was created with the aim of working together to improve OSPO adoption and education within Europe and discuss with the broader community the challenges European organizations face when implementing an open source program.
-
-TODO EU Chapter Members organize public monthly sync meetings open to everyone. If you would like to participate, you can join the EMEA monthly Sync meetings [here](https://community.linuxfoundation.org/todo-group-europe/)
 
 
 


### PR DESCRIPTION
This commit clarifies the community structure at TODO and highlights the OSPOlogy brand for community purposes

Signed-off-by: Ana Jimenez Santamaria <ana@todogroup.org>