### PR TITLE
build(hugo): upgrade hugo version into v0.111.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.64.0"
+HUGO_VERSION = "0.111.3"
 
 [context.deploy-preview]
 command = "make preview-build"


### PR DESCRIPTION
This Pull Request upgrades the Hugo version from 0.64.0 to v0.111.3, which has been resolved todogroup/todogroup.org#374.