### PR TITLE
Custom RSS feed

### DIFF
--- a/content/en/blog/a-year-in-review-2022.md
+++ b/content/en/blog/a-year-in-review-2022.md
@@ -4,18 +4,18 @@ author: todogroup
 date: 2022-12-18
 ---
 
-This past year has been full of challenges and opportunities. TODO Group pursued its mission of 
-helping Open Source Program Office adoption, education, and success within organizations across 
-sectors and regions. The project launched many exciting new initiatives, refined existing ones, 
-and received contributions from open source leaders and OSPO practitioners worldwide. 
+This past year has been full of challenges and opportunities. TODO Group pursued its mission of
+helping Open Source Program Office adoption, education, and success within organizations across
+sectors and regions. The project launched many exciting new initiatives, refined existing ones,
+and received contributions from open source leaders and OSPO practitioners worldwide.
 
-In this post, the TODO Group would like to appreciate and highlight some of the achievements and 
+In this post, the TODO Group would like to appreciate and highlight some of the achievements and
 contributions done in 2022 by its community.
 
 ## 🧩 About TODO 2022 Strategic Goals
 
-Every year, the TODO Steering Committee members gather together to define the [TODO Strategic Goals](https://github.com/todogroup/governance/blob/main/goals.md) 
-for the upcoming year. Requests and feedback submitted by the community are taken into consideration 
+Every year, the TODO Steering Committee members gather together to define the [TODO Strategic Goals](https://github.com/todogroup/governance/blob/main/goals.md)
+for the upcoming year. Requests and feedback submitted by the community are taken into consideration
 when defining these goals. The community can share via the yearly TODO Satisfaction survey, OSPO forum community proposals, or community virtual calls.
 
 In 2022, our strategic goals were:
@@ -33,23 +33,23 @@ In 2022, our strategic goals were:
 
 ### Make it easier to produce high-quality guides and other related OSPO resources
 
-* **Created specific contribution guidelines** to help the community propose, start or contribute to 
-existing resources (Guides, whitepapers, OSPOlogy presentation, OSPO local group, etc). Now, the community 
-can follow a homogeneous process via the OSPOlogy GitHub Discussions under Community Proposals. Examples can 
+* **Created specific contribution guidelines** to help the community propose, start or contribute to
+existing resources (Guides, whitepapers, OSPOlogy presentation, OSPO local group, etc). Now, the community
+can follow a homogeneous process via the OSPOlogy GitHub Discussions under Community Proposals. Examples can
 be found [here](https://github.com/todogroup/ospology/discussions/categories/community-proposals).
 
-* **Improved the [Working Hours virtual calls](https://github.com/todogroup/working-hours#working-hours-documentation)** 
-and encourage people to join existing work-in-progress initiatives such as the [Outbound OSS Guide](https://github.com/todogroup/outbound-oss) 
+* **Improved the [Working Hours virtual calls](https://github.com/todogroup/working-hours#working-hours-documentation)**
+and encourage people to join existing work-in-progress initiatives such as the [Outbound OSS Guide](https://github.com/todogroup/outbound-oss)
 or the [Employee Open Source Engagement Guide](https://github.com/todogroup/todogroup.org/issues?q=is%3Aissue+is%3Aopen+label%3A%22Guide+Employee+Open+Source+Engagement%22).
 
 * **Launched the OSPOlogy Live events in Europe, co-organized with other open source communities to identify OSPO adoption problems in
-Europe**, and work on improving existing (or building new) resources from these communities that can help overcome such challenges and ease such adoption based 
+Europe**, and work on improving existing (or building new) resources from these communities that can help overcome such challenges and ease such adoption based
 on specific region needs.
 
 ### Host 8 OSPOlogy sessions (Webinars - OSPO Use Cases)
 
-OSPOlogy webinars share OSPO Use Cases from real organizations sharing their best practices, 
-problems faced, journeys, or even useful tooling and resources for OSPOs. We are proud to share that 
+OSPOlogy webinars share OSPO Use Cases from real organizations sharing their best practices,
+problems faced, journeys, or even useful tooling and resources for OSPOs. We are proud to share that
 TODO successfully achieved this goal with exciting topics and discussions across the year:
 
 * [Measuring the Business Impact of Open Source & OSPOs - Google](https://community.linuxfoundation.org/events/details/lfhq-todo-group-presents-measuring-the-business-impact-of-open-source-ospos/)
@@ -63,30 +63,30 @@ TODO successfully achieved this goal with exciting topics and discussions across
 
 ### Encourage more active participation in OSPOlogy (Repo)
 
-From OSPO resources like the OSPO Mind Map, OSPO Maturity Model, to global and regional OSPO meetings; OSPOlogy hosts 
-the study and open community communication to discuss the status of open source program offices across regions. 
+From OSPO resources like the OSPO Mind Map, OSPO Maturity Model, to global and regional OSPO meetings; OSPOlogy hosts
+the study and open community communication to discuss the status of open source program offices across regions.
 
 * We worked on improving the README file and the OSPOlogy Repo Governance to clarify the contribution path for OSPO practitioners willing to become part of the OSPOlogy community and contribute to TODO resources.
 * We created an onboarding guide for the OSPOlogy community and share it on the TODO Community page.
 
-As a result, the project hit 100 stars in less than a year and welcome 30+ new core contributors. 
+As a result, the project hit 100 stars in less than a year and welcome 30+ new core contributors.
 Can’t wait to see how this community evolves in the upcoming years!
 
 ### Cultivate relationships with other communities
 
-This was an ongoing process that we started in 2021, and kept refining in 2022. Since the launch of [OSPO Associates program](https://todogroup.org/associates/), 
-we continued looking for new ways to collaborate with other open source communities willing to help the OSPO movement with 
+This was an ongoing process that we started in 2021, and kept refining in 2022. Since the launch of [OSPO Associates program](https://todogroup.org/associates/),
+we continued looking for new ways to collaborate with other open source communities willing to help the OSPO movement with
 specific resources, knowledge, or working groups. Some examples from this cross-community collaboration that happened this year were:
 
 * **[TODO and CHAOSS OSPO Metrics Working Group:](https://github.com/chaoss/wg-ospo)** The OSPO Metrics working group aims to advance how organizations understand the value that open source projects can provide as well as the value of these programs / initiatives.
-* **OSPOlogy Live Workshop in Europe:** A collaborative effort to help organizations in Europe to build and advance in their OSPO journey, co-organized with OpenChain (open source compliance standards), TODO (OSPO management), 
+* **OSPOlogy Live Workshop in Europe:** A collaborative effort to help organizations in Europe to build and advance in their OSPO journey, co-organized with OpenChain (open source compliance standards), TODO (OSPO management),
 InnerSource Commons (Internal open source culture), OpenSSF (security), CHAOSS (metrics and reporting), SPDX (SBoM Standart) and LF Energy (Open source in the energy sector).
 
 TODO also started to collaborate closely with existing OSPO local subgroups within other open source communities such as the OSPO SIG at OpenChain Japan WG (Japanese Language) or the OSPO SIG at LF APAC (Chinese Language).
 
 ### Increase geographical availability
 
-One essential milestone we achieved this year was increasing geographical availability. TODO allocated regional virtual calls within 
+One essential milestone we achieved this year was increasing geographical availability. TODO allocated regional virtual calls within
 OSPOlogy that covered different timezones:
 
 * OSPOlogy Europe Sync Calls
@@ -94,7 +94,7 @@ OSPOlogy that covered different timezones:
 * Working Hours AMER
 * Working Hours EMEA & APAC
 
-Another interesting initiative created in 2022 was the OSPOlogy Live Europe (previously introduced) and the OSPO Local Meetups to improve diversity and inclusion 
+Another interesting initiative created in 2022 was the OSPOlogy Live Europe (previously introduced) and the OSPO Local Meetups to improve diversity and inclusion
 within non-native English speaking countries and thus support OSPO adoption across different regions. Some examples of OSPO local Meetups created are:
 
 * OSPO Local Meetup Geneva (WIP meetups and active slack channel)
@@ -106,30 +106,30 @@ within non-native English speaking countries and thus support OSPO adoption acro
 This year we received the highest number of answers in TODO history. 52 OSPOers completed the survey and gave great feedback on ways to improve our community. Thank you!
 According to the answers:
 
-* Almost 90% of respondents showed overall satisfaction with TODO in 2022 (total percentage of people who ranked 4 “very satisfied” or 5 “extremely satisfied”) 
-* 97% of respondents were likely to recommend TODO in 2022 (total percentage of people who ranked 4 “likely to recommend” or 5 ”very likely to recommend”) 
+* Almost 90% of respondents showed overall satisfaction with TODO in 2022 (total percentage of people who ranked 4 “very satisfied” or 5 “extremely satisfied”)
+* 97% of respondents were likely to recommend TODO in 2022 (total percentage of people who ranked 4 “likely to recommend” or 5 ”very likely to recommend”)
 
 ## 📌 Keep working on
 
 ### Improve and refresh TODO Website
-Something that we started working on but couldn’t finish within the deadline due to some project blockers. So far, we added 
-new pages to the current design such as the [TODO Code Of Conduct](https://todogroup.org/guides/), the [Community Page](https://todogroup.org/community/), or the 
-[OSPO Associates](https://todogroup.org/associates/) as well as have a specific section to presenting the new [OSPO resources](https://todogroup.org/guides/) (studies, whitepapers, training courses, etc). 
+Something that we started working on but couldn’t finish within the deadline due to some project blockers. So far, we added
+new pages to the current design such as the [TODO Code Of Conduct](https://todogroup.org/guides/), the [Community Page](https://todogroup.org/community/), or the
+[OSPO Associates](https://todogroup.org/associates/) as well as have a specific section to presenting the new [OSPO resources](https://todogroup.org/guides/) (studies, whitepapers, training courses, etc).
 Our next goal in 2023 would probably be to make some changes to the current design to be able to implement the [todogorup.org new wireframe](https://github.com/todogroup/todogroup.org/issues?q=is%3Aissue+is%3Aopen+label%3Awebsite).
 
 ### Assess TODO tooling (Slack, Mailing Lists, GitHub)
-Auditing existing TODO tooling is the only strategic goal we couldn’t start in 2022. 
+Auditing existing TODO tooling is the only strategic goal we couldn’t start in 2022.
 We hope to retake this goal early in 2023.
 
 ***
 
 ### Final thoughts
 
-We are very thankful to the worldwide open source community, who came together to contribute their efforts and time 
-by sharing open source best practices and creating Open Source Program Offices resources that anyone can freely 
-use and contribute to. 
+We are very thankful to the worldwide open source community, who came together to contribute their efforts and time
+by sharing open source best practices and creating Open Source Program Offices resources that anyone can freely
+use and contribute to.
 
-We look forward to working and collaborating with everyone in the years to come. We would like to wish you a 
+We look forward to working and collaborating with everyone in the years to come. We would like to wish you a
 peaceful holiday season. Hope you enjoy time with your loved ones and have a relaxed start to the new year.
 
 

--- a/content/en/blog/how-can-ospo-accelerate-innovation-and-digital-transformation.md
+++ b/content/en/blog/how-can-ospo-accelerate-innovation-and-digital-transformation.md
@@ -1,5 +1,5 @@
 ---
-title: "How can OSPOs & collaboration accelerate innovation and digital transformation?"
+title: How can OSPOs & collaboration accelerate innovation and digital transformation?
 author: anajsana
 date: 2021-11-24
 ---
@@ -31,7 +31,7 @@ However, due to the open source complexity, companies across industries are in a
 
 ## OSPO Benefits
 
-One of the many reasons is to consider OSPOs as the strategic Ally to bring order into the organization’s open source operations. If you have an aligned and dedicated person or team working on this on a strategic level, is more likely to coordinate and communicate your goals in a more efficient way across teams (legal, engineering, etc) that can be translated into saving time on bringing open source adoption to the organization. In the race towards digital innovation powered by open source adoption, time means everything. 
+One of the many reasons is to consider OSPOs as the strategic Ally to bring order into the organization’s open source operations. If you have an aligned and dedicated person or team working on this on a strategic level, is more likely to coordinate and communicate your goals in a more efficient way across teams (legal, engineering, etc) that can be translated into saving time on bringing open source adoption to the organization. In the race towards digital innovation powered by open source adoption, time means everything.
 
 Open Source adoption usually faces different stages, from a beginner interaction to a more complex one. According to one of the [OSPO acticle from Ibrahim Haddad](https://www.linkedin.com/pulse/open-source-program-offices-primer-organizational-roles-haddad/), the are four primary open source software strategies:
 
@@ -52,7 +52,7 @@ As mentioned earlier, realizing that your organization is already using open sou
 
 # Pre-OSPO Set Up: Understanding the Environment
 
-The same way we find different open source stages related to an organization’s open source involvement, OSPOs have their own journey as well. While there is a tendency to think that open source initiatives should also begin with external visibility in the open-source ecosystem, those community steps may not work until the organization asses a secure and supportive environment within their internal structure (it can be a hard task to try to build a community if there is no sense of community nor sense of security by the developers and high-level managers in the first place). 
+The same way we find different open source stages related to an organization’s open source involvement, OSPOs have their own journey as well. While there is a tendency to think that open source initiatives should also begin with external visibility in the open-source ecosystem, those community steps may not work until the organization asses a secure and supportive environment within their internal structure (it can be a hard task to try to build a community if there is no sense of community nor sense of security by the developers and high-level managers in the first place).
 
 *Disclaimer: There might be companies that already meet those criteria and might be able to start working on external activities such as organization’s developer engagement across open source projects.*
 
@@ -77,7 +77,7 @@ There are initiatives or communities that can help your organization to accelera
 
 ## 1) In-house Initiatives: Re-purposing Organization’s Assets
 
-Some of these accelerators can be already implemented within the organization. Learning how to effectively communicate with other teams, re-allocate resources and re-use content are the main ingredients needed to avoid replication and work on things that have been already implemented by others. 
+Some of these accelerators can be already implemented within the organization. Learning how to effectively communicate with other teams, re-allocate resources and re-use content are the main ingredients needed to avoid replication and work on things that have been already implemented by others.
 
 ### Example: Building Bridges with InnerSource
 

--- a/content/en/blog/new-member-goldman-sachs.md
+++ b/content/en/blog/new-member-goldman-sachs.md
@@ -1,5 +1,5 @@
 ---
-title: "Goldman Sachs becomes a TODO Member"
+title: Goldman Sachs becomes a TODO Member
 author: todogroup
 date: 2021-11-29
 ---
@@ -7,7 +7,7 @@ date: 2021-11-29
 
 Goldman Sachs joins the TODO Group as part of launching an Open Source Program Office (OSPO), to accelerate its investment in open source and innovation.
 
-Goldman Sachs has been contributing to open source for nearly a decade, finding new ways to advance in their Open Source journey. 
+Goldman Sachs has been contributing to open source for nearly a decade, finding new ways to advance in their Open Source journey.
 In August, Goldman Sachs formalized its commitment to open source and created an Open Source Program Office (OSPO).
 
 > As we have seen work well at other companies, having a single team responsible for the open source strategy will allow us to accelerate and deepen our investment in open source.

--- a/content/en/blog/open-source-program-management-tools.md
+++ b/content/en/blog/open-source-program-management-tools.md
@@ -35,8 +35,7 @@ Insights into the behavior and state of open source projects is critically impor
 
 [GHTorrent](http://ghtorrent.org) is an open source research project run by Georgios Gousios ([@gousiosg](https://github.com/gousiosg)) that archives all public GitHub events, all entities referenced from those events (transitively), and a set of links derived from these events and entities.  The data is stored in a combination of MySQL and MongoDB and goes back in time to 2012.  This is phenomenal resource for open source communities.  It is easy to get raw data on GitHub usage as @ghtorrent tweeted recently:
 
-<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Yesterday, Github got 10k new users, 43k new repos, 40k new issues, 27k new PRs, 84k new issue coments and 600k new commits <a href="https://twitter.com/hashtag/scale?src=hash">#scale</a></p>&mdash; GHTorrent (@ghtorrent) <a href="https://twitter.com/ghtorrent/status/692226721836306432">January 27, 2016</a></blockquote>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+{{< tweet user="ghtorrent" id="692226721836306432" >}}
 
 The data enables deeper insights such as the [interactive programming language usage site](http://langpop.corger.nl/) shown below.
 

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,17 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title>{{ .Site.Title }}</title>
+        <description>TODO is an open community of practitioners who aim to create and share knowledge, collaborate on practices, tools, and other ways to run successful and effective Open Source Program Offices and similar Open Source initiatives.</description>
+        <link>{{ .Site.BaseURL }}</link>
+        <atom:link href="{{ .Site.BaseURL }}index.xml" rel="self" type="application/rss+xml" />
+        {{ range where .Site.RegularPages "Section" "eq" "blog" }}
+        <item>
+            <title>{{ .Title }}</title>
+            <guid>{{ .Permalink }}</guid>
+            <link>{{ .Permalink }}</link>
+            <description>{{ .Summary | replaceRE "&ldquo;" "\"" | replaceRE "&rdquo;" "\"" | replaceRE "&rsquo;" "'" | replaceRE "&mdash;" "—" | safeHTML }}</description>
+        </item>
+        {{ end }}
+    </channel>
+</rss>


### PR DESCRIPTION
I've implemented a custom RSS feed to fix the issue that was experience by Chrome users when clicking directly on the RSS feed link  - #401 

`This page contains the following errors:
error on line 4 at column 868: Entity 'rsquo' not defined`

Note:
- The RSS Feed works if loaded in to RSS Viewer / Feedly / any RSS reader directly
- Safari does not display error
- Chrome displays error

The custom feed shows blog posts only. It implements some custom find and replace to remove some HTML entities that were being flagged by XML Validator. There may be a better approach or a "Hugo" way of doing this, but I couldn't find it.

The feed is now a "valid" RSS feed and the error has gone from Chrome.

![Screenshot-2023-10-19 --20 21 38](https://github.com/todogroup/todogroup.org/assets/10615884/18132048-45ea-464b-8b32-b251bafc7316)

![Screenshot-2023-10-19 --20 22 11@2x](https://github.com/todogroup/todogroup.org/assets/10615884/3b3239bb-8a7a-43fe-88f5-a0b89778daa9)
