### PR TITLE
Fix typo 2023 -> 2024

### DIFF
--- a/content/en/blog/2024-steering-committee.md
+++ b/content/en/blog/2024-steering-committee.md
@@ -5,7 +5,7 @@ date: 2023-12-02
 ---
 
 We are excited to announce the composition of 2024 Steering Committee (SC) on the Linux Foundation's
-TODO Group project. The 2023 SC includes elected members: Ashley Wolf from GitHub (returning), 
+TODO Group project. The 2024 SC includes elected members: Ashley Wolf from GitHub (returning), 
 Stephen Augustus from Cisco (returning), Nik Peters from Porsche (new) and appointed members: 
 Brittany Istenes from Fannie Mae (new).
 


### PR DESCRIPTION
This PR fixes a small typo where it should state *2024* instead of *2023*.