### PR TITLE
Update iframe embed url for landscape view at todo website

### DIFF
--- a/layouts/shortcodes/todo_associates.html
+++ b/layouts/shortcodes/todo_associates.html
@@ -1,6 +1,6 @@
 <!-- Embed list of all OSPO Associate -->
 <iframe
-  src="https://landscape.todogroup.org/card-mode?category=ospo-associate&grouping=category&embed=yes&style=borderless"
+  src="https://landscape.todogroup.org/embed/embed.html?key=ospo-adopter--ospo-associate&headers=true&category-header=false&category-in-subcategory=false&item-name=false&title-uppercase=false&title-alignment=left&title-font-family=sans-serif&title-font-size=15&style=clean&size=xl&items-alignment=center&bg-color=%23ffffff&fg-color=%23a4a4a4"
   frameborder="0"
   id="landscape"
   width="1000"

--- a/layouts/shortcodes/todo_group_members.html
+++ b/layouts/shortcodes/todo_group_members.html
@@ -1,12 +1,11 @@
 <!-- Embed list of all Open Mainframe Project members -->
-<iframe
-  src="https://landscape.todogroup.org/card-mode?category=todo-group-member&embed=yes&style=borderless"
-  frameborder="0"
+<iframe 
+  src="https://landscape.todogroup.org/embed/embed.html?key=todo-group-member--general&headers=true&category-header=false&category-in-subcategory=true&item-name=false&title-uppercase=false&title-alignment=left&title-font-family=sans-serif&title-font-size=20&style=clean&size=lg&items-alignment=center&bg-color=%23ffffff&fg-color=%23929292" 
+  style="width:100%;height:100%;display:block;border:none;"
   id="landscape"
   scrolling="no"
-  width="1000"
   loading="lazy"
-  style="width: 1px; min-width: 100%; opacity: 1; visibility: visible; overflow: hidden; height: 1717px;"
   title="List of all Open Mainframe Project members"
 ></iframe>
+
 <script src="https://landscape.todogroup.org/iframeResizer.js"></script>

--- a/layouts/shortcodes/todo_group_members.html
+++ b/layouts/shortcodes/todo_group_members.html
@@ -1,11 +1,7 @@
 <!-- Embed list of all Open Mainframe Project members -->
 <iframe 
-  src="https://landscape.todogroup.org/embed/embed.html?key=todo-group-member--general&headers=true&category-header=false&category-in-subcategory=true&item-name=false&title-uppercase=false&title-alignment=left&title-font-family=sans-serif&title-font-size=20&style=clean&size=lg&items-alignment=center&bg-color=%23ffffff&fg-color=%23929292" 
+  src="https://landscape.todogroup.org/embed/embed.html?key=todo-group-member--general&headers=true&category-header=false&category-in-subcategory=true&item-name=false&title-uppercase=false&title-alignment=left&title-font-family=sans-serif&title-font-size=15&style=clean&size=lg&items-alignment=left&bg-color=%23fdfdfd&fg-color=%238f8f8f" 
   style="width:100%;height:100%;display:block;border:none;"
-  id="landscape"
-  scrolling="no"
-  loading="lazy"
-  title="List of all Open Mainframe Project members"
 ></iframe>
 
 <script src="https://landscape.todogroup.org/iframeResizer.js"></script>

--- a/layouts/shortcodes/todo_group_members.html
+++ b/layouts/shortcodes/todo_group_members.html
@@ -1,7 +1,13 @@
 <!-- Embed list of all Open Mainframe Project members -->
 <iframe 
   src="https://landscape.todogroup.org/embed/embed.html?key=todo-group-member--general&headers=true&category-header=false&category-in-subcategory=true&item-name=false&title-uppercase=false&title-alignment=left&title-font-family=sans-serif&title-font-size=15&style=clean&size=lg&items-alignment=left&bg-color=%23fdfdfd&fg-color=%238f8f8f" 
-  style="width:100%;height:100%;display:block;border:none;"
+  frameborder="0"
+  id="landscape"
+  scrolling="no"
+  width="1000"
+  loading="lazy"
+  style="width: 1px; min-width: 100%; opacity: 1; visibility: visible; overflow: hidden; height: 1717px;"
+  title="List of all Open Mainframe Project members"
 ></iframe>
 
 <script src="https://landscape.todogroup.org/iframeResizer.js"></script>


### PR DESCRIPTION
[OSPO Landscape has migrated to a new view](https://github.com/todogroup/ospolandscape/issues/193) and now the url for iframes follows a different structure. Before the DNS switch available at: https://ospo.landscape2.io/embed-setup, after at https://landscape.todogroup.org/embed-setup

This PR updates the iframe embed url so the member organizations can be seen