### PR TITLE
chore(osponews): add remaining newsletter to archive

### DIFF
--- a/content/en/osponews.md
+++ b/content/en/osponews.md
@@ -50,3 +50,12 @@ Subscribe for updates, event info, webinars, and the latest community news:
 - [OSPO Newsletter 30](https://email.linuxfoundation.org/osponews-issue-30)
 {{< /column >}}
 {{< /columns >}}
+{{< column >}}
+- [OSPO Newsletter 31](https://github.com/todogroup/ospology/blob/main/newsletter/2024-06-07.md)
+- [OSPO Newsletter 32](https://email.linuxfoundation.org/osponews-issue-32)
+- [OSPO Newsletter 33](https://email.linuxfoundation.org/osponews-issue-33)
+- [OSPO Newsletter 34](https://email.linuxfoundation.org/osponews-issue-34)
+- [OSPO Newsletter 35](https://email.linuxfoundation.org/osponews-issue-35)
+- [OSPO Newsletter 36](https://email.linuxfoundation.org/osponews-issue-36)
+- [OSPO Newsletter 37](https://email.linuxfoundation.org/osponews-issue-37)
+{{< /column >}}


### PR DESCRIPTION
Adds the remaining newsletter to the newsletter archive so that people can see newsletters from 31 to 37 editions on the website.

![image](https://github.com/user-attachments/assets/72e7ef39-d2d0-4cef-95ac-6e4560119ccb)
 

