### PR TITLE
chore(associates): fix link to `Guides and Resources page`

### DIFF
--- a/content/en/associates.md
+++ b/content/en/associates.md
@@ -70,7 +70,7 @@ Netlify will generate a staging server for you to preview your updates. Please c
 
 ## Where can I find more info?
 
-There are a lot of initiatives & resources where an OSPO Associate can get involved that are listed in the [TODO Guides and Resources](todogroup.org/guides).
+There are a lot of initiatives & resources where an OSPO Associate can get involved that are listed in the [TODO Guides and Resources](https://todogroup.org/resources/guides).
 
 If you would like to know where your specific project initiatives could fit in the TODO programs or would like to know more details, please contact ana@todogroup.org and she will schedule a Sync call to answer any questions.
 

--- a/content/zh-CN/associates.md
+++ b/content/zh-CN/associates.md
@@ -68,7 +68,7 @@ Netlify 会自动为您创建一个预览版本。请确认 logo 和相关信息
 
 ## 想要获取更多信息，我应该去哪里？
 
-作为 OSPO 合作伙伴，您可以参与众多的项目和资源，这些都列在 [TODO 指南和资源](todogroup.org/guides) 中。
+作为 OSPO 合作伙伴，您可以参与众多的项目和资源，这些都列在 [TODO 指南和资源](https://todogroup.org/resources/guides) 中。
 
 如果您想了解您的项目是如何融入 TODO 的各种计划，或者希望获取更多相关信息，您可以联系 ana@todogroup.org，她会安排一个同步通话来回答任何问题。
 


### PR DESCRIPTION
**Where can I find more info?** heading of [Associates](https://todogroup.org/about/associates/) links to a non-working link for TODO Guides and Resources link, which links to https://todogroup.org/about/associates/todogroup.org/guides, which is 404; it should have been https://todogroup.org/resources/guides/ instead.


Solves https://github.com/todogroup/todogroup.org/issues/538