### PR TITLE
chore(studies): fix ospo structure report link

### DIFF
--- a/content/en/studies/structure.md
+++ b/content/en/studies/structure.md
@@ -1,6 +1,6 @@
 ---
 title: A Deep Dive into OSPO
 ---
-[A Deep Dive into Open Source Program Offices](https://www.linuxfoundation.org/toolsa-deep-dive-into-open-source-program-offices/) Includes OSPO characteristics, structures, roles, responsibilities, and challenges.
+[A Deep Dive into Open Source Program Offices](https://www.linuxfoundation.org/tools/a-deep-dive-into-open-source-program-offices/) Includes OSPO characteristics, structures, roles, responsibilities, and challenges.
 
-{{< button link="https://www.linuxfoundation.org/toolsa-deep-dive-into-open-source-program-offices/" text=" Download The Report" >}}
+{{< button link="https://www.linuxfoundation.org/tools/a-deep-dive-into-open-source-program-offices/" text=" Download The Report" >}}


### PR DESCRIPTION
Fixes A Deep Dive into Open Source Program Offices report link. 

Earlier, it was giving 404 as the URL was `https://www.linuxfoundation.org/toolsa-deep-dive-into-open-source-program-offices/`

The correct link is `https://www.linuxfoundation.org/tools/a-deep-dive-into-open-source-program-offices/`