### PR TITLE
chore: use OSPO Book URL

### DIFF
--- a/content/en/blog/ospo-book-pdf-version.md
+++ b/content/en/blog/ospo-book-pdf-version.md
@@ -12,10 +12,10 @@ Whether your organization is using, contributing to, or building open source sof
 
 The OSPO Book includes collaboratively developed insights, frameworks, and tools contributed by OSPO professionals across industries. It covers key topics such as:
 
-- **Chapter 1**: Introduction to Open Source Program Offices  
-- **Chapter 2**: The Value of Open Source Program Offices  
-- **Chapter 3**: Creating Your OSPO  
-- **Chapter 4**: Day-to-Day Operations  
+- **Chapter 1**: Introduction to Open Source Program Offices
+- **Chapter 2**: The Value of Open Source Program Offices
+- **Chapter 3**: Creating Your OSPO
+- **Chapter 4**: Day-to-Day Operations
 - NEW **Chapter 5**: Managing Open Source Security (In collaboration with OpenSSF)
 - NEW **Chapter 6**: Using Metrics in your OSPO (In collaboration with CHAOSS)
 
@@ -25,7 +25,7 @@ The release of this edition would not have been possible without the invaluable 
 
 You can browse the extensive list of 20+ Subject Matter Experts (SMEs) who have contributed to the book chapters [here](https://ospobook.todogroup.org/07-chapter/)
 
-{{< button link="https://github.com/user-attachments/files/21504526/OSPOBook_Report_2025_v7.1.pdf" text=" Download OSPO Book PDF" >}}
+{{< button link="https://github.com/todogroup/ospology/releases/download/ospo-book-en-v1/OSPOBook.pdf" text=" Download OSPO Book PDF" >}}
 
 People attending onsite at [OSSummit Europe in Amsterdam](https://events.linuxfoundation.org/open-source-summit-europe/) can get a printed copy in the OSPOCon Track
 

--- a/content/en/book.md
+++ b/content/en/book.md
@@ -7,4 +7,4 @@ url: "/resources/book/"
 The OSPO Book includes resources developed collaboratively across organizations for effective open source management through OSPOs. It is intended for those organizations looking to develop strategies to use, contribute to, or create open source projects.
 {{< /intro >}}
 
-{{< button link="https://ospobook.todogroup.org" text="Explore the Book" >}} {{< button link="https://github.com/user-attachments/files/21504526/OSPOBook_Report_2025_v7.1.pdf" text="Download the Book (PDF)" >}} {{< button link="https://lists.todogroup.org/g/WG-ospo-book-project" style="secondary" text="Learn how to contribute" >}}
+{{< button link="https://ospobook.todogroup.org" text="Explore the Book" >}} {{< button link="https://github.com/todogroup/ospology/releases/download/ospo-book-en-v1/OSPOBook.pdf" text="Download the Book (PDF)" >}} {{< button link="https://lists.todogroup.org/g/WG-ospo-book-project" style="secondary" text="Learn how to contribute" >}}


### PR DESCRIPTION
This PR changes the URL of the OSPO Book PDF to the GitHub releases, which is more consistent and easier to update.