### PR TITLE
Update authors.yaml to modify company affiliations

### DIFF
--- a/data/authors.yaml
+++ b/data/authors.yaml
@@ -12,7 +12,6 @@ jerpelea:
 nruff:
   name: Nithya Ruff
   twitter: nithyaruff
-  company: SanDisk
 bvanevery:
   name: Benjamin VanEvery
   twitter: bvanevery
@@ -20,19 +19,19 @@ bvanevery:
 bkeepers:
   name: Brandon Keepers
   twitter: bkeepers
-  company: GitHub
 gianugo:
   name: Gianugo Rabellino
   twitter: gianugo
-  company: Microsoft
 caniszczyk:
   name: Chris Aniszczyk
   twitter: cra
   company: CNCF
+chrisxie:
+  name: Chris Xie
+  company: Futurewei
 gyehuda:
   name: Gil Yehuda
   twitter: gyehuda
-  company: Verizon Media
 dalmaer:
   name: Dion Almaer
   twitter: dalmaer
@@ -43,7 +42,6 @@ geethujoseph:
 nzakas:
   name: Nicholas C. Zakas
   twitter: slicknet
-  company: Box
 anajsana:
   name: Ana Jimenez Santamaria
   company: The Linux Foundation


### PR DESCRIPTION
Removed companies for Nithya Ruff, Brandon Keepers, and Gil Yehuda. Added Chris Xie with company Futurewei.